### PR TITLE
FIX: `ls()` implementation to avoid recursing to subdirs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 .ipy*
 dist/*
 .idea
+.venv

--- a/dropboxdrivefs/core.py
+++ b/dropboxdrivefs/core.py
@@ -47,7 +47,7 @@ class DropboxDriveFileSystem(AbstractFileSystem):
         self.session = requests.Session()
         self.session.auth = ("Authorization", self.token)
 
-    def ls(self, path, detail=True, **kwargs):
+    def ls(self, path, detail=True, recursive=False, **kwargs):
         """ List objects at path
         """
         path = path.replace("//", "/")
@@ -55,7 +55,7 @@ class DropboxDriveFileSystem(AbstractFileSystem):
 
         try:
             list_item = self.dbx.files_list_folder(
-                path, recursive=True, include_media_info=True
+                path, recursive=recursive, include_media_info=True
             )
         except ApiError as error:
             logging.warning(error)


### PR DESCRIPTION
# What
- Breaking change: Fixed ls to not be recursive by default
- Added `.venv` to gitignore

# Why
- This was not in line with other fsspec implementations which leads to inconsistent file listing
- Described in [this issue](https://github.com/iterative/PyDrive2/issues/307).